### PR TITLE
Check for "dataroot" setting in the config file

### DIFF
--- a/DSC/grapher/config.pm
+++ b/DSC/grapher/config.pm
@@ -105,6 +105,8 @@ sub read_config {
 			$CONFIG{debug_fh} = new IO::File("> $fn");
 		} elsif ($directive eq 'debug_level') {
 			$CONFIG{debug_level} = shift @x;
+		} elsif ($directive eq 'dataroot') {
+			$CONFIG{$directive} = shift @x;
 		}
 	}
 	close(F);


### PR DESCRIPTION
The grapher looks for files relative to "dataroot", but the config module doesn't even look for this option in the config file. This patch fixes that anomaly.
